### PR TITLE
fix invocation of ScannerTestRegex

### DIFF
--- a/festival.py
+++ b/festival.py
@@ -27,7 +27,7 @@ def main():
     myapp, args = simple_main()
     if args.test_regex:
         from scanner import ScannerTestRegex
-        ScannerTestRegex(myapp.config['SCANNER_PATH']).start()
+        ScannerTestRegex(myapp.config).start()
     elif not args.check:
         if args.with_scanner:
             from scanner import Scanner


### PR DESCRIPTION
The README file suggests to test the folder patters with `python3 festival.py --test-regex` but the constructor of Scanner requires the complete `config` object.